### PR TITLE
feat：浏览器标题根据标题栏颜色变化

### DIFF
--- a/harmony/inappbrowser/src/main/ets/components/PhoneLayout.ets
+++ b/harmony/inappbrowser/src/main/ets/components/PhoneLayout.ets
@@ -1,26 +1,19 @@
-/**
- * MIT License
+/*
+ * Copyright (c) 2024 Huawei Device Co., Ltd.
  *
- * Copyright (C) 2024 Huawei Device Co., Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import { Browser } from '../model/Browser';
 import { ToolPone, toolPoneArray } from '../model/LoadViewData';
 import { WebTab } from './TitleBar';
@@ -138,21 +131,16 @@ export struct PhoneLayout {
             this.resultType = "cancel";
             context.terminateSelf();
           })
-        Text(){
-           if(this.browser.inputValue) {
-             ImageSpan(this.isLightTheme ? $r('app.media.ic_public_white_lock'):$r("app.media.ic_public_blank_lock"))
-               .width('16')
-               .height('16')
-               .margin({left:2,right:2})
-             Span(this.browser.hostUrlName).fontSize(20).textCase(TextCase.Normal).fontColor(this.isLightTheme ? '#FFFFFF' :'#000000')
-           }
-          }
-          .textOverflow({ overflow: TextOverflow.Clip })
-          .maxLines(1)
-          .fontWeight(400)
-          .layoutWeight(1)
-          .textAlign(TextAlign.Center)
-
+        Row() {
+           Image(this.isLightTheme ? $r('app.media.ic_public_white_lock'):$r("app.media.ic_public_blank_lock"))
+             .width('16')
+             .height('16')
+             .margin({left:2,right:2})
+             .fillColor(this.isLightTheme ? '#FFFFFF' :'#000000')
+          Text(this.browser.hostUrlName).fontSize(20).textCase(TextCase.Normal).fontColor(this.isLightTheme ? '#FFFFFF' :'#000000')
+        }
+        .layoutWeight(1)
+        .justifyContent(FlexAlign.Center)
         Image($r("app.media.ic_public_refresh"))
           .fillColor(this.tintColor)
           .width(25)


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：
   closes #12 
1.新增功能，浏览器标题根据标题栏颜色变化
## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
测试用例：
https://github.com/react-native-oh-library/RNOHDCS/tree/main/react-native-inappbrowser
测试用例一条与测试用例第二条，可对比标题根据标题栏颜色颜色变化

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

-  [X]  已经在真机设备或模拟器上测试通过
-  [X] 已经与 Android 或 iOS 平台做过效果/功能对比
-  [X]  已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)